### PR TITLE
feat: VM + DNS etec.cloud.um.edu.ar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# Infrastructure as code demo for ETEC
+
+Create a VM to "mirror" <https://etec.um.edu.ar/> `index.html` (using
+Ubuntu 22.04 LTS image and nginx package) on GCP (Google Cloud
+Platform), to make it available at <http://etec.cloud.um.edu.ar/>.
+
+Add needed firewall entry for http (port 80) and DNS record for
+`etec.cloud.um.edu.ar`.

--- a/infra-as-code/.gitignore
+++ b/infra-as-code/.gitignore
@@ -1,0 +1,2 @@
+terraform.tfstate
+.terraform*

--- a/infra-as-code/.gitignore
+++ b/infra-as-code/.gitignore
@@ -1,2 +1,2 @@
-terraform.tfstate
+terraform.tfstate*
 .terraform*

--- a/infra-as-code/Makefile
+++ b/infra-as-code/Makefile
@@ -1,0 +1,22 @@
+help:
+	@echo make init
+	@echo make deploy
+	@echo make undeploy
+	@echo make show
+init: tf-init
+	
+deploy: tf-apply
+undeploy: tf-destroy
+show: tf-output
+
+tf-init:
+	terraform init
+
+tf-apply:
+	terraform apply #--auto-approve
+
+tf-destroy:
+	terraform destroy #--auto-approve
+
+tf-output:
+	terraform output

--- a/infra-as-code/dns.tf
+++ b/infra-as-code/dns.tf
@@ -1,0 +1,15 @@
+// Obtenter una referencia a la zona DNS
+data "google_dns_managed_zone" "cloud_um_edu_ar" {
+  name = "cloud-um-edu-ar"
+}
+
+// Crear la entrada DNS etec.cloud.um.edu.ar
+resource "google_dns_record_set" "etec" {
+  name         = "etec.${data.google_dns_managed_zone.cloud_um_edu_ar.dns_name}"
+  managed_zone = data.google_dns_managed_zone.cloud_um_edu_ar.name
+  type         = "A"
+  ttl          = 120
+
+  rrdatas = [google_compute_instance.vm_01.network_interface.0.access_config.0.nat_ip]
+}
+

--- a/infra-as-code/firewall.tf
+++ b/infra-as-code/firewall.tf
@@ -1,0 +1,17 @@
+// Obtener una ref a la "default" VPC (network)
+data "google_compute_network" "default" {
+  name = "default"
+}
+
+// Crear una entrada de firewall para http (port 80), aplicarla
+// a las VMs con tag="http"
+resource "google_compute_firewall" "allow-http" {
+  name    = "fw-allow-http"
+  network = data.google_compute_network.default.name
+  allow {
+    protocol = "tcp"
+    ports    = ["80"]
+  }
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["http"]
+}

--- a/infra-as-code/main.tf
+++ b/infra-as-code/main.tf
@@ -1,0 +1,10 @@
+provider "google" {
+  project = "um-cloud-221804"
+  region  = "us-central1"
+  zone    = "us-central1-c"
+}
+# Ver:
+# - vm.tf
+# - firewall.tf
+# - dns.tf
+# - output.tf

--- a/infra-as-code/output.tf
+++ b/infra-as-code/output.tf
@@ -1,6 +1,7 @@
 output "vm_01_url_ip" {
-  value = "http://${google_compute_instance.vm_01.network_interface.0.access_config.0.nat_ip}"
-}
-output "vm_01_url_name" {
-  value = "http://${google_dns_record_set.etec.name}"
+  value = {
+    url_ip   = "http://${google_compute_instance.vm_01.network_interface.0.access_config.0.nat_ip}",
+    url_name = "http://${google_dns_record_set.etec.name}"
+    ssh_cli = "ssh -oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null ubuntu@${google_dns_record_set.etec.name}"
+  }
 }

--- a/infra-as-code/output.tf
+++ b/infra-as-code/output.tf
@@ -1,0 +1,6 @@
+output "vm_01_url_ip" {
+  value = "http://${google_compute_instance.vm_01.network_interface.0.access_config.0.nat_ip}"
+}
+output "vm_01_url_name" {
+  value = "http://${google_dns_record_set.etec.name}"
+}

--- a/infra-as-code/template/install_nginx.tpl
+++ b/infra-as-code/template/install_nginx.tpl
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+echo "*****    Installing Nginx    *****"
+apt update
+apt install -y nginx wget
+ufw allow 'Nginx HTTP'
+systemctl enable nginx
+systemctl restart nginx
+sudo su - ubuntu -c 'ssh-import-id jjo'
+sudo su - ubuntu -c 'ssh-import-id navarrow'
+wget --no-check-certificate -P /var/www/html/  https://etec.um.edu.ar

--- a/infra-as-code/vm.tf
+++ b/infra-as-code/vm.tf
@@ -15,7 +15,6 @@ resource "google_compute_instance" "vm_01" {
   machine_type = "e2-micro"
   tags         = ["http"]
 
-
   boot_disk {
     initialize_params {
       image = data.google_compute_image.ubuntu.self_link

--- a/infra-as-code/vm.tf
+++ b/infra-as-code/vm.tf
@@ -1,0 +1,33 @@
+// Obtener una referencia a la imagen Ubuntu 22.04 LTS
+data "google_compute_image" "ubuntu" {
+  family  = "ubuntu-2204-lts"
+  project = "ubuntu-os-cloud"
+}
+
+// Proveemos un template para startup script 
+data "template_file" "nginx" {
+  template = file("${path.module}/template/install_nginx.tpl")
+}
+
+// Crear la VM
+resource "google_compute_instance" "vm_01" {
+  name         = "vm-01"
+  machine_type = "e2-micro"
+  tags         = ["http"]
+
+
+  boot_disk {
+    initialize_params {
+      image = data.google_compute_image.ubuntu.self_link
+    }
+  }
+
+  network_interface {
+    # A default network is created for all GCP projects
+    network = "default"
+    access_config {
+    }
+  }
+  metadata_startup_script = data.template_file.nginx.rendered
+}
+


### PR DESCRIPTION
- `main.tf`: initialize GCP provider
- `vm.tf`: create VM with ubuntu 22.04 LTS + nginx deploy, copying <https://etec.um.edu.ar> as nginx's index.html
- `firewall.tf`: add needed firewall entry for http (port 80)
- `dns.tf`: add DNS record for etec.cloud.um.edu.ar
- `output.tf`: show ip and FQDN urls
